### PR TITLE
chore: verify submodule auth issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ This repo is intended to be leveraged as a git submodule.
 ```bash
 mkdir sub_modules
 cd sub_modules
-git submodule add [Repo URL]
+git submodule add git@github.com:[User Name]/[Repo Name].git
 cd ..
 npm i "./sub_modules/[Repo Name]" --save
 ```
+**Note**: When working with Github, and ideally in all situations, use SSH URIs.
+
 
 ## License
 This project and all of its contents is not licensed for any purpose whatsoever.


### PR DESCRIPTION
Verify submodule authentication issue

Root cause: using the HTTP path when adding the submodule configures git to authenticate using basic auth while Github fully deprecated that access pattern.

Solution:
When working with an already initialized submodule in a project, that submodule should be removed and re-initialized.

From the project root:
```
rm -rf .git/modules/[module's path]
git config --remove-section submodule.[module's path]
```

I also found that the `.gitmodules` file needed to have the entry removed, but that could have been the result of user error on my part as I was working to find a solution.

This PR updates the installation instructions for this submodule and was created from within a consuming git repo following those instructions.